### PR TITLE
Fix the link in deployment section

### DIFF
--- a/appengine/README.md
+++ b/appengine/README.md
@@ -67,8 +67,8 @@ The datastore maintains all state for active requests.
 
 ### Deployment
 
-Splice App is written in Go. See "[Deploying a Go
-App](https://cloud.google.com/appengine/docs/standard/go/tools/uploadinganapp)"
+Splice App is written in Go. See "[Building a Go
+App](https://cloud.google.com/appengine/docs/standard/go/building-app)"
 for information on how to deploy splice to App Engine in your project.
 
 ### Project Whitelist


### PR DESCRIPTION
The link for deploying a Go app is no longer working. I am replacing it with building a Go app. Please tell me if this is not the right link.